### PR TITLE
修复读取离线文件Reader传入symbol已有市场代码时前缀还有市场代码

### DIFF
--- a/mootdx/reader.py
+++ b/mootdx/reader.py
@@ -55,7 +55,7 @@ class ReaderBase(ABC):
         :return: pd.dataFrame or None
         """
         market = get_stock_market(symbol, True) if len(symbol.split('#')) == 1 else 'ds'
-        prefix = market if len(symbol.split('#')) == 1 else ''
+        prefix = market if len(symbol.split('#')) == 1 and not symbol.startswith('s') else ''
         suffix = suffix if isinstance(suffix, list) else [suffix]
 
         for ex_ in suffix:


### PR DESCRIPTION
比如读取指数文件, symbol='sh000001'  , prefix='sh', vipdoc=xxx/shsh000001.day