### PR TITLE
Update reversion.py

### DIFF
--- a/mootdx/tools/reversion.py
+++ b/mootdx/tools/reversion.py
@@ -15,7 +15,7 @@ def factor_reversion(symbol: str, method: str = 'qfq', raw: pd.DataFrame = None)
         raw = raw.sort_index(ascending=True)
 
         data = pd.concat([raw, factor.loc[raw.index[0]: raw.index[-1], ['factor']]], axis=1)
-        data.factor = data.factor.fillna(method=('ffill', 'bfill')[method == 'qfq'], axis=0)
+        data.factor = data.factor.ffill() if method == 'qfq' else data.factor.bfill()
         data.factor = data.factor.fillna(1.0, axis=0)
         data.factor = data.factor.astype(float)
 


### PR DESCRIPTION
修正mootdx/tools/reversion.py:18: FutureWarning: Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version. Call result.infer_objects(copy=False) instead. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`
  data.factor = data.factor.fillna(method=('ffill', 'bfill')[method == 'qfq'], axis=0)